### PR TITLE
Pass credentials on logout

### DIFF
--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -402,7 +402,7 @@ class RelyingParty extends JSONDocument {
     let uri = configuration.end_session_endpoint
     let method = 'get'
 
-    return fetch(uri, {method})
+    return fetch(uri, {method, credentials: 'include'})
       .then(onHttpError('Error logging out'))
 
     // TODO: Validate `frontchannel_logout_uri` if necessary


### PR DESCRIPTION
While logoutRequest is being prepared,
the only way to log out is to call `/logout`
while passing the cookie to the server.