### PR TITLE
Send credentials on logout

### DIFF
--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -298,7 +298,11 @@ class RelyingParty extends JSONDocument {
 
     this.clearSession()
 
-    return Promise.resolve(configuration.end_session_endpoint)
+    let uri = configuration.end_session_endpoint
+    let method = 'get'
+
+    return fetch(uri, {method})
+      .then(onHttpError('Error logging out'))
 
     // TODO: Validate `frontchannel_logout_uri` if necessary
     /**

--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -397,13 +397,17 @@ class RelyingParty extends JSONDocument {
       return Promise.reject(error)
     }
 
-    this.clearSession()
+    if (!configuration.end_session_endpoint) {
+      this.clearSession()
+      return Promise.resolve(undefined)
+    }
 
     let uri = configuration.end_session_endpoint
     let method = 'get'
 
     return fetch(uri, {method, credentials: 'include'})
       .then(onHttpError('Error logging out'))
+      .then(() => this.clearSession())
 
     // TODO: Validate `frontchannel_logout_uri` if necessary
     /**

--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -402,7 +402,7 @@ class RelyingParty extends JSONDocument {
     let uri = configuration.end_session_endpoint
     let method = 'get'
 
-    return fetch(uri, {method})
+    return fetch(uri, {method, credentials: 'include'})
       .then(onHttpError('Error logging out'))
 
     // TODO: Validate `frontchannel_logout_uri` if necessary

--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -298,11 +298,7 @@ class RelyingParty extends JSONDocument {
 
     this.clearSession()
 
-    let uri = configuration.end_session_endpoint
-    let method = 'get'
-
-    return fetch(uri, {method})
-      .then(onHttpError('Error logging out'))
+    return Promise.resolve(configuration.end_session_endpoint)
 
     // TODO: Validate `frontchannel_logout_uri` if necessary
     /**

--- a/test/RelyingPartySpec.js
+++ b/test/RelyingPartySpec.js
@@ -261,7 +261,8 @@ describe('RelyingParty', () => {
 
       return rp.logout().should.be.rejectedWith(/OpenID Configuration is missing end_session_endpoint/)
     })
-
+//disable
+/****
     it('should make a request to the end_session_endpoint', () => {
       let logoutRequest = nock(providerUrl).get('/logout').reply(200)
 
@@ -276,7 +277,9 @@ describe('RelyingParty', () => {
           expect(logoutRequest.isDone()).to.be.true()
         })
     })
-
+****/
+//disable
+/***
     it('should reject on http error', done => {
       let providerUrl = 'https://notfound'
 
@@ -296,6 +299,7 @@ describe('RelyingParty', () => {
           done()
         })
     })
+***/
   })
 
   describe('register', () => {

--- a/test/RelyingPartySpec.js
+++ b/test/RelyingPartySpec.js
@@ -261,8 +261,7 @@ describe('RelyingParty', () => {
 
       return rp.logout().should.be.rejectedWith(/OpenID Configuration is missing end_session_endpoint/)
     })
-//disable
-/****
+
     it('should make a request to the end_session_endpoint', () => {
       let logoutRequest = nock(providerUrl).get('/logout').reply(200)
 
@@ -277,9 +276,7 @@ describe('RelyingParty', () => {
           expect(logoutRequest.isDone()).to.be.true()
         })
     })
-****/
-//disable
-/***
+
     it('should reject on http error', done => {
       let providerUrl = 'https://notfound'
 
@@ -299,7 +296,6 @@ describe('RelyingParty', () => {
           done()
         })
     })
-***/
   })
 
   describe('register', () => {


### PR DESCRIPTION
@RubenVerborgh 
I added fix for add credential for /logout call and updated code for call clearSession().
I an not sure about fix for clearSession() calls, may be it isn't nessesary, but I think that session must be cleared, when /logout was really done.